### PR TITLE
feat: adjust ui for DiagramMain and fix display problem for line-chart

### DIFF
--- a/taiwan-dashboard-2021/components/DiagramElectric.vue
+++ b/taiwan-dashboard-2021/components/DiagramElectric.vue
@@ -29,7 +29,7 @@
       :class="{ hide: !isToggled }"
     >
       <!-- Paste Diagram component in here -->
-      <div class="diagram-electric__diagram__line-chart-container">
+      <div v-if="power" class="diagram-electric__diagram__line-chart-container">
         <LineChart
           :power="power"
           :currentElectricLoading="currentElectricLoading"

--- a/taiwan-dashboard-2021/components/DiagramMain.vue
+++ b/taiwan-dashboard-2021/components/DiagramMain.vue
@@ -7,11 +7,12 @@
 
     <div class="g-diagram__board_wrapper">
       <BoardHandler
-        boardType="number"
-        :count="currentCovidCount"
+        boardType="multi-number"
+        :leftCount="currentCovidCount"
+        :rightCount="currentCovidDeathCount"
         unit="例"
         :isNeededPlus="true"
-        :info="['今日新增本土確診數']"
+        :info="['今日新增本土確診數/死亡人數']"
         anchorId="diagram-covid-19"
       />
       <BoardHandler
@@ -54,7 +55,12 @@ export default {
     currentCovidCount: {
       type: Number,
       isRequired: true,
-      default: 254,
+      default: 0,
+    },
+    currentCovidDeathCount: {
+      type: Number,
+      isRequired: true,
+      default: 0,
     },
     currentElectricLoading: {
       type: String,

--- a/taiwan-dashboard-2021/components/Power/LineChart.vue
+++ b/taiwan-dashboard-2021/components/Power/LineChart.vue
@@ -232,7 +232,7 @@ export default {
         .append('rect')
         .attr('class', 'tooltip')
         .attr('x', 10)
-        .attr('y', -22)
+        .attr('y', -150)
         .attr('width', 120)
         .attr('height', 60)
         .attr('rx', 1)

--- a/taiwan-dashboard-2021/pages/index.vue
+++ b/taiwan-dashboard-2021/pages/index.vue
@@ -5,6 +5,7 @@
     <div class="homepage__diagram_wrapper">
       <DiagramMain
         :currentCovidCount="currentCovidCount"
+        :currentCovidDeathCount="currentCovidDeathCount"
         :currentElectricLoading="currentElectricLoading"
         :currentElectricStatusColor="currentElectricStatusColor"
         :currentWaterStatus="currentWaterStatus"
@@ -83,6 +84,9 @@ export default {
   computed: {
     currentCovidCount() {
       return this.covid?.today || 0
+    },
+    currentCovidDeathCount() {
+      return this.covid?.death_today || 0
     },
     todayData() {
       return this.power?.power_24h_today ?? []


### PR DESCRIPTION
1. 修正電力圖 tooltip 初次 hover 時的顯示問題，將預設位置移至 view-box 畫面之外
2. 若電力資料未取得，則不顯示折線圖
3. 主表單疫情區塊新增死亡人數資料