### PR TITLE
feat: adjust ui for line-chart and covid-list

### DIFF
--- a/taiwan-dashboard-2021/components/BoardTitle.vue
+++ b/taiwan-dashboard-2021/components/BoardTitle.vue
@@ -22,9 +22,12 @@
 
     <template v-else>
       <div class="board-title__region">
-        <h3 class="board-title__region_status">
+        <h3 v-if="regions" class="board-title__region_status">
           {{ regionStatus }}
         </h3>
+        <h2 v-else class="board-title__region_status">
+          {{ regionStatus }}
+        </h2>
         <h5 class="board-title__region_regions">
           {{ regions }}
         </h5>

--- a/taiwan-dashboard-2021/components/DiagramCovid19CityListItem.vue
+++ b/taiwan-dashboard-2021/components/DiagramCovid19CityListItem.vue
@@ -60,6 +60,9 @@ export default {
   justify-content: space-between;
   border-bottom: 1px solid rgba(0, 9, 40, 0.1);
   padding: 2px 0;
+  &:last-child {
+    border-bottom: none;
+  }
   & > div {
     display: flex;
     align-items: center;

--- a/taiwan-dashboard-2021/components/Power/LineChart.vue
+++ b/taiwan-dashboard-2021/components/Power/LineChart.vue
@@ -169,7 +169,7 @@ export default {
             .tickFormat((d, i) => `${i * xAxisTickInterval}時`)
         )
         .call((g) => g.selectAll('.tick line').attr('y2', 0))
-        .call((g) => g.selectAll('.tick text').attr('font-size', 14))
+        .call((g) => g.selectAll('.tick text').attr('font-size', 10))
         .select('.domain')
         .remove()
 
@@ -188,8 +188,8 @@ export default {
           g
             .selectAll('.tick text')
             .attr('x', -margin.left)
-            .attr('dy', -5)
-            .attr('font-size', 12)
+            .attr('dy', -3)
+            .attr('font-size', 8)
             .attr('fill', '#000928')
             .attr('opacity', 0.1)
             .attr('text-anchor', 'start')


### PR DESCRIPTION
1. 調整折線圖字級大小
2. 當主版面水情狀況為單行時，字級大小調整為與電力狀況標題相同
3. 刪除疫情城市列表最後一項的底線